### PR TITLE
유저 정보 관리 페이지 추가 - 유저 주문 조회 컨트롤러 구현

### DIFF
--- a/src/main/java/joo/project/my3d/controller/UserAdminController.java
+++ b/src/main/java/joo/project/my3d/controller/UserAdminController.java
@@ -1,9 +1,12 @@
 package joo.project.my3d.controller;
 
+import joo.project.my3d.dto.OrdersDto;
 import joo.project.my3d.dto.UserAccountDto;
 import joo.project.my3d.dto.request.UserAdminRequest;
+import joo.project.my3d.dto.response.OrdersResponse;
 import joo.project.my3d.dto.response.UserAdminResponse;
 import joo.project.my3d.dto.security.BoardPrincipal;
+import joo.project.my3d.service.OrdersService;
 import joo.project.my3d.service.UserAccountService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +18,8 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import java.util.List;
+
 @Slf4j
 @Controller
 @RequestMapping("/user")
@@ -22,9 +27,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class UserAdminController {
 
     private final UserAccountService userAccountService;
+    private final OrdersService ordersService;
 
     @GetMapping("/account")
-    public String UserData(
+    public String userData(
             @AuthenticationPrincipal BoardPrincipal boardPrincipal,
             Model model
     ) {
@@ -49,5 +55,17 @@ public class UserAdminController {
             userAccountService.changePassword(userAdminRequest.email(), userAdminRequest.password());
         }
         return "redirect:/user/account";
+    }
+
+    @GetMapping("/orders")
+    public String orders(
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal,
+            Model model
+    ) {
+        List<OrdersResponse> ordersResponses = ordersService.getOrders(boardPrincipal.email()).stream()
+                                                .map(OrdersResponse::from).toList();
+        model.addAttribute("userRole", boardPrincipal.getUserRole());
+        model.addAttribute("orders", ordersResponses);
+        return "user/orders";
     }
 }

--- a/src/main/java/joo/project/my3d/dto/response/OrdersResponse.java
+++ b/src/main/java/joo/project/my3d/dto/response/OrdersResponse.java
@@ -1,0 +1,27 @@
+package joo.project.my3d.dto.response;
+
+import joo.project.my3d.domain.Address;
+import joo.project.my3d.domain.constant.OrderStatus;
+import joo.project.my3d.dto.OrdersDto;
+
+public record OrdersResponse(
+        String productName,
+        String zipcode,
+        String detail,
+        String street,
+        OrderStatus status
+) {
+    public static OrdersResponse of(String productName, String zipcode, String detail, String street, OrderStatus status) {
+        return new OrdersResponse(productName, zipcode, detail, street, status);
+    }
+
+    public static OrdersResponse from(OrdersDto dto) {
+        return OrdersResponse.of(
+                dto.productName(),
+                dto.addressDto().zipcode(),
+                dto.addressDto().detailAddress(),
+                dto.addressDto().address(),
+                dto.status()
+        );
+    }
+}

--- a/src/main/resources/templates/user/orders.html
+++ b/src/main/resources/templates/user/orders.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/test/java/joo/project/my3d/controller/UserAdminControllerTest.java
+++ b/src/test/java/joo/project/my3d/controller/UserAdminControllerTest.java
@@ -6,6 +6,7 @@ import joo.project.my3d.domain.constant.UserRole;
 import joo.project.my3d.dto.UserAccountDto;
 import joo.project.my3d.dto.properties.JwtProperties;
 import joo.project.my3d.fixture.FixtureDto;
+import joo.project.my3d.service.OrdersService;
 import joo.project.my3d.service.UserAccountService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,10 +18,9 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.event.annotation.BeforeTestMethod;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Optional;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
@@ -37,6 +37,7 @@ class UserAdminControllerTest {
     @Autowired private MockMvc mvc;
     @MockBean private UserAccountService userAccountService;
     @MockBean private CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+    @MockBean private OrdersService ordersService;
 
     @DisplayName("[GET] 계정 관리 페이지")
     @Test
@@ -80,5 +81,25 @@ class UserAdminControllerTest {
         // Then
         then(userAccountService).should().updateUser(any(UserAccountDto.class));
         then(userAccountService).should().changePassword(anyString(), anyString());
+    }
+
+    @DisplayName("[GET] 주문 관리 페이지")
+    @Test
+    void orders() throws Exception {
+        // Given
+        given(ordersService.getOrders(anyString())).willReturn(anyList());
+        UsernamePasswordAuthenticationToken authentication = FixtureDto.getAuthentication("userUser", UserRole.USER);
+        // When
+        mvc.perform(
+                        get("/user/orders")
+                                .with(authentication(authentication))
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("user/orders"))
+                .andExpect(model().attributeExists("userRole"))
+                .andExpect(model().attributeExists("orders"));
+        // Then
+        then(ordersService).should().getOrders(anyString());
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 유저는 자신이 주문한 내역을 확인 할 수 있어야합니다. 이를 위해 로그인(인증)된 유저에대한 주문들을 조회하는 기능을 구현합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 유저의 주문을 조회하는 서비스 로직은 이미 구현되어있으므로 주문 목록 페이지에 대한 컨트롤러를 추가했습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2: 적극적으로 고려해 주세요 (Request changes)
    * P3: 웬만하면 반영해 주세요 (Comment)
    * P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
    * P5: 그냥 사소한 의견입니다 (Approve)
## Issue Tags
- Closed: #64 
