### PR TITLE
SSE(Server-Sent Events)를 사용한 알람 기능 구현 - 알람 기능 적용

### DIFF
--- a/src/main/java/joo/project/my3d/domain/Alarm.java
+++ b/src/main/java/joo/project/my3d/domain/Alarm.java
@@ -28,7 +28,7 @@ public class Alarm extends AuditingFields {
     @Column(nullable = false)
     private String fromUserEmail; //알람을 발생시킨 유저
     @Column(nullable = false)
-    private Long targetId; //게시글과 같은 알람의 대상이되는 엔티티의 id
+    private Long targetId; //게시글, 기업 엔티티의 id
 
     @ToString.Exclude
     @ManyToOne(optional = false, fetch = FetchType.LAZY)

--- a/src/main/java/joo/project/my3d/service/ArticleLikeService.java
+++ b/src/main/java/joo/project/my3d/service/ArticleLikeService.java
@@ -1,8 +1,11 @@
 package joo.project.my3d.service;
 
+import joo.project.my3d.domain.Alarm;
 import joo.project.my3d.domain.Article;
 import joo.project.my3d.domain.ArticleLike;
 import joo.project.my3d.domain.UserAccount;
+import joo.project.my3d.domain.constant.AlarmType;
+import joo.project.my3d.repository.AlarmRepository;
 import joo.project.my3d.repository.ArticleLikeRepository;
 import joo.project.my3d.repository.ArticleRepository;
 import joo.project.my3d.repository.UserAccountRepository;
@@ -18,6 +21,8 @@ public class ArticleLikeService {
     private final ArticleRepository articleRepository;
     private final UserAccountRepository userAccountRepository;
     private final ArticleLikeRepository articleLikeRepository;
+    private final AlarmRepository alarmRepository;
+    private final AlarmService alarmService;
 
     @Transactional
     public void addArticleLike(Long articleId, String userId) {
@@ -27,6 +32,15 @@ public class ArticleLikeService {
 
         article.addLike();
         articleLikeRepository.save(articleLike);
+        Alarm alarm = alarmRepository.save(
+                Alarm.of(
+                        AlarmType.NEW_LIKE_ON_POST,
+                        userAccount.getEmail(),
+                        article.getId(),
+                        article.getUserAccount()
+                )
+        );
+        alarmService.send(article.getUserAccount().getEmail(), alarm.getId());
     }
 
     @Transactional
@@ -36,4 +50,6 @@ public class ArticleLikeService {
         article.deleteLike();
         articleLikeRepository.deleteByArticleId(articleId);
     }
+
+
 }

--- a/src/main/java/joo/project/my3d/service/OrdersService.java
+++ b/src/main/java/joo/project/my3d/service/OrdersService.java
@@ -1,21 +1,26 @@
 package joo.project.my3d.service;
 
+import joo.project.my3d.domain.Alarm;
 import joo.project.my3d.domain.Company;
 import joo.project.my3d.domain.Orders;
 import joo.project.my3d.domain.UserAccount;
+import joo.project.my3d.domain.constant.AlarmType;
 import joo.project.my3d.dto.OrdersDto;
 import joo.project.my3d.exception.ErrorCode;
 import joo.project.my3d.exception.OrdersException;
+import joo.project.my3d.repository.AlarmRepository;
 import joo.project.my3d.repository.CompanyRepository;
 import joo.project.my3d.repository.OrdersRepository;
 import joo.project.my3d.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -26,6 +31,8 @@ public class OrdersService {
     private final OrdersRepository ordersRepository;
     private final UserAccountRepository userAccountRepository;
     private final CompanyRepository companyRepository;
+    private final AlarmRepository alarmRepository;
+    private final AlarmService alarmService;
 
 
     public List<OrdersDto> getOrdersByEmail(String email) {
@@ -47,6 +54,18 @@ public class OrdersService {
             Company company = companyRepository.getReferenceById(dto.companyDto().id());
             Orders orders = dto.toEntity(userAccount, company);
             ordersRepository.save(orders);
+
+            UserAccount companyUserAccount = userAccountRepository.findByCompanyId(company.getId())
+                    .orElseThrow(() -> new UsernameNotFoundException("기업 유저를 찾을 수 없습니다. id=" + company.getId()));
+            Alarm alarm = alarmRepository.save(
+                    Alarm.of(
+                            AlarmType.NEW_ORDER,
+                            userAccount.getEmail(),
+                            company.getId(),
+                            companyUserAccount
+                    )
+            );
+            alarmService.send(companyUserAccount.getEmail(), alarm.getId());
         } catch (EntityNotFoundException e) {
             log.warn("주문 저장 실패! - {}", new OrdersException(ErrorCode.FAILED_SAVE));
         }

--- a/src/test/java/joo/project/my3d/service/ArticleLikeServiceTest.java
+++ b/src/test/java/joo/project/my3d/service/ArticleLikeServiceTest.java
@@ -1,10 +1,14 @@
 package joo.project.my3d.service;
 
+import joo.project.my3d.domain.Alarm;
 import joo.project.my3d.domain.ArticleLike;
+import joo.project.my3d.domain.UserAccount;
 import joo.project.my3d.fixture.Fixture;
+import joo.project.my3d.repository.AlarmRepository;
 import joo.project.my3d.repository.ArticleLikeRepository;
 import joo.project.my3d.repository.ArticleRepository;
 import joo.project.my3d.repository.UserAccountRepository;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,23 +27,32 @@ class ArticleLikeServiceTest {
     @Mock ArticleLikeRepository articleLikeRepository;
     @Mock ArticleRepository articleRepository;
     @Mock UserAccountRepository userAccountRepository;
+    @Mock private AlarmRepository alarmRepository;
+    @Mock private AlarmService alarmService;
 
     @DisplayName("좋아요 추가")
     @Test
-    void addArticleLike() {
+    void addArticleLike() throws IllegalAccessException {
         // Given
         Long articleId = 1L;
         String userId = "joo";
         ArticleLike articleLike = Fixture.getArticleLike();
+        UserAccount userAccount = Fixture.getUserAccount();
+        Alarm alarm = Fixture.getAlarm(userAccount);
+        FieldUtils.writeField(alarm, "id", 1L, true);
         given(articleRepository.getReferenceById(articleId)).willReturn(articleLike.getArticle());
         given(userAccountRepository.getReferenceById(userId)).willReturn(articleLike.getUserAccount());
         given(articleLikeRepository.save(any(ArticleLike.class))).willReturn(articleLike);
+        given(alarmRepository.save(any(Alarm.class))).willReturn(alarm);
+        willDoNothing().given(alarmService).send(eq(userAccount.getEmail()), eq(1L));
         // When
         articleLikeService.addArticleLike(articleId, userId);
         // Then
         then(articleRepository).should().getReferenceById(articleId);
         then(userAccountRepository).should().getReferenceById(userId);
         then(articleLikeRepository).should().save(any(ArticleLike.class));
+        then(alarmRepository).should().save(any(Alarm.class));
+        then(alarmService).should().send(eq(userAccount.getEmail()), eq(1L));
     }
 
     @DisplayName("좋아요 삭제")


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 유저가 게시글에 좋아요를 누르거나 댓글을 작성하거나 주문을 요청했을때 해당 게시글 작성자에게 알람을 보낼 수 있어야합니다. 따라서 `좋아요`, `댓글`, `주문` 저장시 알람을 전송하도록 구현합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- `좋아요`, `댓글`, `주문` 저장에 대한 서비스 로직에 각각 알람 전송 로직을 추가했습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2: 적극적으로 고려해 주세요 (Request changes)
    * P3: 웬만하면 반영해 주세요 (Comment)
    * P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
    * P5: 그냥 사소한 의견입니다 (Approve)

## Issue Tags
- Closed: #83 