### PR TITLE
UserAccount의 JPA N+1 문제 해결

### DIFF
--- a/src/main/java/joo/project/my3d/repository/UserAccountRepository.java
+++ b/src/main/java/joo/project/my3d/repository/UserAccountRepository.java
@@ -1,13 +1,16 @@
 package joo.project.my3d.repository;
 
 import joo.project.my3d.domain.UserAccount;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
     Optional<UserAccount> findByCompanyId(Long companyId);
+    @EntityGraph(attributePaths = {"company", "userRefreshToken"})
     Optional<UserAccount> findByEmail(String email);
+    @EntityGraph(attributePaths = {"company", "userRefreshToken"})
     UserAccount getReferenceByEmail(String email);
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);

--- a/src/main/java/joo/project/my3d/service/ArticleCommentService.java
+++ b/src/main/java/joo/project/my3d/service/ArticleCommentService.java
@@ -40,8 +40,6 @@ public class ArticleCommentService {
     @Transactional
     public void saveComment(ArticleCommentDto dto) {
         try{
-            //TODO: UserAccount에 접근하면서 N+1 문제가 발생 (userAccount + company + userRefreshToken)
-            // -> @OneToOne 관계라 조회시 EAGER Loading이 적용됨
             UserAccount userAccount = userAccountRepository.getReferenceByEmail(dto.email());
             ArticleComment articleComment = dto.toEntity(
                     articleRepository.getReferenceById(dto.articleId()),

--- a/src/main/java/joo/project/my3d/service/ArticleCommentService.java
+++ b/src/main/java/joo/project/my3d/service/ArticleCommentService.java
@@ -40,6 +40,8 @@ public class ArticleCommentService {
     @Transactional
     public void saveComment(ArticleCommentDto dto) {
         try{
+            //TODO: UserAccount에 접근하면서 N+1 문제가 발생 (userAccount + company + userRefreshToken)
+            // -> @OneToOne 관계라 조회시 EAGER Loading이 적용됨
             UserAccount userAccount = userAccountRepository.getReferenceByEmail(dto.email());
             ArticleComment articleComment = dto.toEntity(
                     articleRepository.getReferenceById(dto.articleId()),


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- UserAccount를 findByEmail 또는 getReferenceByEmail로 조회할때 OneToOne 관계를 가지는 엔티티가 EAGER Loading되면서 N+1문제가 발생하는 것을 확인했습니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- UserAccount, Company, UserRefreshToken을 join fetch함으로써 해결했습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2: 적극적으로 고려해 주세요 (Request changes)
    * P3: 웬만하면 반영해 주세요 (Comment)
    * P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
    * P5: 그냥 사소한 의견입니다 (Approve)

## Issue Tags
- Closed | Fixed: #
- See also: #
